### PR TITLE
Use wdl-runner in australian region

### DIFF
--- a/wdl_runner/run_lifesciences.sh
+++ b/wdl_runner/run_lifesciences.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+BUCKET="cpg-peter-dev"
+
+gcloud beta lifesciences pipelines run \
+    --pipeline-file wdl_pipeline.yaml \
+    --regions australia-southeast1 \
+    --inputs-from-file WDL=test-wdl/ga4ghMd5.wdl,WORKFLOW_INPUTS=test-wdl/ga4ghMd5.inputs.json,WORKFLOW_OPTIONS=test-wdl/basic.papi.australia.options.json \
+    --env-vars WORKSPACE=gs://${BUCKET}/wdl_runner/work,OUTPUTS=gs://${BUCKET}/wdl_runner/output \
+    --logging gs://${BUCKET}/wdl_runner/logging

--- a/wdl_runner/run_lifesciences.sh
+++ b/wdl_runner/run_lifesciences.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUCKET="cpg-peter-dev"
+BUCKET="<my-bucket>"
 REGION="australia-southeast1"
 
 gcloud beta lifesciences pipelines run \

--- a/wdl_runner/run_lifesciences.sh
+++ b/wdl_runner/run_lifesciences.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
 BUCKET="cpg-peter-dev"
+REGION="australia-southeast1"
 
 gcloud beta lifesciences pipelines run \
     --pipeline-file wdl_pipeline.yaml \
-    --regions australia-southeast1 \
+    --location ${REGION} \
+    --regions ${REGION} \
     --inputs-from-file WDL=test-wdl/ga4ghMd5.wdl,WORKFLOW_INPUTS=test-wdl/ga4ghMd5.inputs.json,WORKFLOW_OPTIONS=test-wdl/basic.papi.australia.options.json \
     --env-vars WORKSPACE=gs://${BUCKET}/wdl_runner/work,OUTPUTS=gs://${BUCKET}/wdl_runner/output \
     --logging gs://${BUCKET}/wdl_runner/logging

--- a/wdl_runner/test-wdl/basic.papi.australia.options.json
+++ b/wdl_runner/test-wdl/basic.papi.australia.options.json
@@ -1,0 +1,6 @@
+{
+  "default_runtime_attributes": {
+          "zones": "australia-southeast1-a australia-southeast1-b australia-southeast1-c"
+  }
+}
+

--- a/wdl_runner/wdl_pipeline.yaml
+++ b/wdl_runner/wdl_pipeline.yaml
@@ -7,7 +7,7 @@ actions:
     22: 22 
 - containerName: WDL_Runner
   commands: [ '/wdl_runner/wdl_runner.sh' ]
-  imageUri: broadinstitute/wdl-runner:latest
+  imageUri: australia-southeast1-docker.pkg.dev/peter-dev-302805/pd-ar-repo/wdl_runner:1.0
 
 resources:
    virtualMachine:


### PR DESCRIPTION
Adding script for running a toy WDL workflow on a Cromwell instance (spun up automatically and based on Docker image in Australian GCP artifact registry) through [Cloud Life Sciences](https://cloud.google.com/life-sciences).
Also adjusting VM compute zones to `australia-southeast1`.
The Cromwell instance is automatically killed upon completion.